### PR TITLE
Sort dicts to prevent unwanted file changes

### DIFF
--- a/templates/interfaces.j2
+++ b/templates/interfaces.j2
@@ -135,7 +135,7 @@ iface {{ bridge.name }} inet {{ bridge.type|default(network_management_default_t
 ################################################################################
 # OpenVswitch Patchfield, connect requested ports together
 ################################################################################
-{% for patch_field_dev_in, patch_field_dev_out in patch_field.iteritems() %}
+{% for patch_field_dev_in, patch_field_dev_out in patch_field.iteritems()|sort %}
 # link between {{ patch_field_dev_in }} and {{ patch_field_dev_out }}
 post-up ovs-vsctl {{''
 	-}} --may-exist add-port {{ patch_field_dev_in }} {{ patch_field_dev_in }}_patch_{{ loop.index }} -- {{''
@@ -159,7 +159,7 @@ post-up ip r replace default via {{ network_management_default_gateway }}{% if n
 
 
 # set additional routes
-{% for route_net, route_options in network_management_routes.iteritems() %}
+{% for route_net, route_options in network_management_routes.iteritems()|sort %}
 	{%- if not route_net|search("/[0-9]*") -%}
           {%- set route_net=route_net+"/32" -%}
 	{%- endif -%}


### PR DESCRIPTION
Dicts are not sorted by default and they can appear in different orders
at each play. This causes a network configuration change, even if
nothing is actually changed.