### PR TITLE
[warning fix] use new search syntax

### DIFF
--- a/tasks/interfaces.yml
+++ b/tasks/interfaces.yml
@@ -43,7 +43,7 @@
       [{%- for item in interfaces -%}
       {%- set n_ips=[] -%}
       {%- for ip in item['ips'] -%}
-        {%- if ip|search("/[0-9]*") -%}
+        {%- if ip is search("/[0-9]*") -%}
           {%- set n_ip=ip -%}
         {%- else -%}
           {%- set n_ip=ip+network_management_default_cidr -%}


### PR DESCRIPTION
The old syntax led to a warning when executing `./scripts/playbook.sh`.