### PR TITLE
tasks/main: Fix v6support check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,8 +3,7 @@
   tags: network_management
 
 - name: Check whether IPv6 can be disabled
-  stat:
-    path: /proc/sys/net/ipv6/conf/default/disable_ipv6
+  shell: sysctl --values net.ipv6.conf.default.disable_ipv6
   register: v6support
 
 - import_tasks: interfaces.yml

--- a/templates/interfaces.j2
+++ b/templates/interfaces.j2
@@ -232,7 +232,7 @@ post-up {{ network_management_post_up }}
 ################################################################################
 # sysctl operations
 ################################################################################
-{% if v6support.stat.exists %}
+{% if v6support.stdout == "1" %}
 pre-up sysctl -w net.ipv6.conf.default.disable_ipv6={{ network_management_disable_ipv6 | int }}
 pre-up sysctl -w net.ipv6.conf.all.disable_ipv6={{ network_management_disable_ipv6 | int }}
 {% endif %}


### PR DESCRIPTION
The result previously wasn't correct if the file existed but
set the variable to 0.