### PR TITLE
Revert "tasks/main: Fix v6support check"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,8 @@
   tags: network_management
 
 - name: Check whether IPv6 can be disabled
-  shell: sysctl --values net.ipv6.conf.default.disable_ipv6
+  stat:
+    path: /proc/sys/net/ipv6/conf/default/disable_ipv6
   register: v6support
   changed_when: False
 

--- a/templates/interfaces.j2
+++ b/templates/interfaces.j2
@@ -238,7 +238,7 @@ post-up {{ network_management_post_up }}
 ################################################################################
 # sysctl operations
 ################################################################################
-{% if v6support.stdout == "1" %}
+{% if v6support.stat.exists %}
 pre-up sysctl -w net.ipv6.conf.default.disable_ipv6={{ network_management_disable_ipv6 | int }}
 pre-up sysctl -w net.ipv6.conf.all.disable_ipv6={{ network_management_disable_ipv6 | int }}
 {% endif %}


### PR DESCRIPTION
Reverts stuvusIT/network_management#64

By checking if the value is `1`, this will only add the pre-up to disable v6 if v6 is already disabled...
I think checking whether the file should be enough. Although there must have been a reason for this PR in the first place.
I propose reverting this because the current code is definitely not the semantic we want. If something breaks/fails we'll have to fix it.