### PR TITLE
Revert "tasks/interfaces.yml: Validate systemd unit files"

### DIFF
--- a/tasks/interfaces.yml
+++ b/tasks/interfaces.yml
@@ -88,7 +88,6 @@
   template:
     src: networking.service.j2
     dest: /etc/systemd/system/networking.service.d/override.conf
-    validate: systemd-analyze verify %s
   notify: reload_systemd
 
 - name: Add iproute2 routing tables


### PR DESCRIPTION

Validating does not work, because Ansible does not use the correct file suffix in its temp files. That suffix would be needed for systemd to detect the unti type. See https://github.com/ansible/ansible/issues/19232